### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://sonhoai272.visualstudio.com/c8d3b4ab-f431-4625-b0a5-37f37805ea02/f27b3279-3116-4440-bdac-c15f8fdd4175/_apis/work/boardbadge/d47d68bb-5aa0-4bda-915e-a6d322cd8329)](https://sonhoai272.visualstudio.com/c8d3b4ab-f431-4625-b0a5-37f37805ea02/_boards/board/t/f27b3279-3116-4440-bdac-c15f8fdd4175/Microsoft.RequirementCategory)
 "# iMusik-Reactjs" 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://sonhoai272.visualstudio.com/c8d3b4ab-f431-4625-b0a5-37f37805ea02/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.